### PR TITLE
V1.0.14 fix MonoNode compare issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.0.14] - 2025-01-02
+
+### Fixed
+- [MonoNode] MonoNode comparing on Node not build not correct. Empty ID of either node will not be equal.
+
 ## [1.0.13] - 2025-01-01
 
 ### Fixed

--- a/Runtime/Mono/MonoNode_Comparable.cs
+++ b/Runtime/Mono/MonoNode_Comparable.cs
@@ -1,4 +1,5 @@
 using System;
+using AceLand.Library.Extensions;
 using AceLand.NodeFramework.Core;
 
 namespace AceLand.NodeFramework.Mono
@@ -8,7 +9,10 @@ namespace AceLand.NodeFramework.Mono
         public bool Equals(INode other)
         {
             if (other == null) return false;
-            return Id == other.Id;
+            if (other.Id.IsNullOrEmptyOrWhiteSpace()) return false;
+            if (this.Id.IsNullOrEmptyOrWhiteSpace()) return false;
+            
+            return Id == other.Id && this.GetType() == other.GetType();
         }
 
         // Override Object.Equals
@@ -28,6 +32,10 @@ namespace AceLand.NodeFramework.Mono
         public int CompareTo(INode other)
         {
             if (other == null) return 1;
+            if (other.Id.IsNullOrEmptyOrWhiteSpace()) return 1;
+            if (this.Id.IsNullOrEmptyOrWhiteSpace()) return 1;
+            if (this.GetType() != other.GetType()) return 1;
+            
             return string.Compare(Id, other.Id); 
         }
 
@@ -35,10 +43,12 @@ namespace AceLand.NodeFramework.Mono
         public int CompareTo(object obj)
         {
             if (obj == null) return 1;
+            if (obj is not INode other) return 1;
+            if (other.Id.IsNullOrEmptyOrWhiteSpace()) return 1;
+            if (other.Id.IsNullOrEmptyOrWhiteSpace()) return 1;
+            if (this.GetType() != obj.GetType()) return 1;
 
-            if (obj is INode other)
-                return CompareTo(other);
-
+            return CompareTo(other);
             throw new ArgumentException("Object is not a MyClass");
         }
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.aceland.nodeframework",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "displayName": "AceLand Node Framework",
   "description": "AceLand Node Framework is a framework designed for Unity.\n\nPlease visit our [Git Book](https://aceland-workshop.gitbook.io/aceland-unity-packages).",
   "unity": "2022.3",


### PR DESCRIPTION
Child MonoNode may not ready on building node structure, child node id may be empty.
Equals will now return false if either nodes id is empty or null.