### PR TITLE
V1.0.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,17 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.0.18] - 2025-02-04
+
+### Fixed
+- [MonoNode] duplicated initial root node if no childnode.
+- [MonoNode] rename StartOnNodeReady() to NodeAwake() for correct processing meaning.
+- [MonoNode] add OnNodeReadyAction(Action) to apply actions after NodeAwake invoked.
+
 ## [1.0.17] - 2025-02-03
 
 ### Modify
-- [MonoNode] remove test debug log from ContainerNode
+- [MonoNode] remove test debug log from ContainerNode.
 
 ## [1.0.16] - 2025-01-25
 
@@ -14,7 +21,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 - [MonoNode] add extension .MonoNeighbour<T>() and .MonoNeighbour<T>(id).
 ### Modify
-- [Editor] AceLand Project Setting as Tree structure
+- [Editor] AceLand Project Setting as Tree structure.
 
 ## [1.0.15] - 2025-01-14
 

--- a/Runtime/Mono/MonoNode.cs
+++ b/Runtime/Mono/MonoNode.cs
@@ -10,6 +10,7 @@ namespace AceLand.NodeFramework.Mono
     {
         [Header("Node for Mono")]
         [SerializeField] private protected string nodeId;
+        [SerializeField] private protected bool setAsRoot;
         [SerializeField] private protected bool autoRegistry = true;
 
         public string Id { get => NodeReady ? _id : nodeId ; protected set => _id = value; }
@@ -21,7 +22,6 @@ namespace AceLand.NodeFramework.Mono
         internal ChildNode ChildNode  { get; set; }
         ChildNode INode.ChildNode => ChildNode;
 
-
         public virtual bool IsActive => gameObject.activeInHierarchy;
 
         public virtual void SetActive(bool active) => gameObject.SetActive(active);
@@ -31,6 +31,8 @@ namespace AceLand.NodeFramework.Mono
         public GameObject Go { get; protected set; }
         public Transform Tr { get; protected set; }
         public bool NodeReady { get; protected set; }
+
+        private event Action _onNodeReady;
 
         public bool AutoRegistry
         {
@@ -45,17 +47,29 @@ namespace AceLand.NodeFramework.Mono
             Id = adjId;
         }
 
+        public void OnNodeReadyAction(Action action)
+        {
+            if (NodeReady)
+            {
+                action?.Invoke();
+                return;
+            }
+
+            _onNodeReady += action;
+        }
+
         internal virtual void InitialNode()
         {
         }
 
-        internal void OnNodeReadyProcess()
+        internal virtual void OnNodeReadyProcess()
         {
+            NodeAwake();
             NodeReady = true;
-            StartAfterNodeBuilt();
+            _onNodeReady?.Invoke();
         }
 
-        protected virtual void StartAfterNodeBuilt()
+        protected virtual void NodeAwake()
         {
             // override this function to run codes required NodeTree ready
         }

--- a/Runtime/Mono/MonoNodeExtension.cs
+++ b/Runtime/Mono/MonoNodeExtension.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using AceLand.NodeFramework.Core;
@@ -8,10 +8,10 @@ namespace AceLand.NodeFramework.Mono
 {
     public static class MonoNodeExtension
     {
-        internal static void InitialMonoNode(this MonoNode monoNode)
+        internal static void InitialMonoNode(this MonoNode monoNode, bool setAsRoot = false)
         {
             if (monoNode.NodeReady) return;
-            if (monoNode.FindParentNode() != null) return;
+            if (!setAsRoot && monoNode.FindParentNode() != null) return;
             
             var allNode = new List<MonoNode>();
             var nodeList = new List<MonoNode> { monoNode };
@@ -19,13 +19,16 @@ namespace AceLand.NodeFramework.Mono
             while (nodeList.Count > 0)
             {
                 var node = nodeList[0];
+                nodeList.Remove(node);
+                if (allNode.Contains(node)) continue;
+                
                 allNode.Add(node);
                 nodeList.Remove(node);
                 
                 node.InitialNode();
                 
                 var parentNode = node.FindParentNode() as MonoNode;
-                var isRoot = parentNode == null;
+                var isRoot = setAsRoot || parentNode == null;
                 if (isRoot) node.ParentNode.SetAsRoot();
                 else node.ParentNode.Set(parentNode);
 

--- a/Runtime/Mono/MonoNodeT.cs
+++ b/Runtime/Mono/MonoNodeT.cs
@@ -10,9 +10,11 @@ namespace AceLand.NodeFramework.Mono
     {
         public T Concrete { get; private set; }
 
+        private event Action<T> _onNodeTReady;
+
         protected virtual void Awake()
         {
-            this.InitialMonoNode();
+            this.InitialMonoNode(setAsRoot);
         }
 
         protected virtual void OnDestroy()
@@ -31,6 +33,23 @@ namespace AceLand.NodeFramework.Mono
             ParentNode = new ParentNode(Concrete);
             ChildNode = new ChildNode(Concrete);
             if (autoRegistry) Concrete.Register();
+        }
+
+        public void OnNodeReadyAction(Action<T> action)
+        {
+            if (NodeReady)
+            {
+                action?.Invoke(Concrete);
+                return;
+            }
+
+            _onNodeTReady += action;
+        }
+
+        internal override void OnNodeReadyProcess()
+        {
+            base.OnNodeReadyProcess();
+            _onNodeTReady?.Invoke(Concrete);
         }
 
         public override void SetId(string id)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.aceland.nodeframework",
-  "version": "1.0.17",
+  "version": "1.0.18",
   "displayName": "AceLand Node Framework",
   "description": "AceLand Node Framework is a framework designed for Unity.\n\nPlease visit our [Git Book](https://aceland-workshop.gitbook.io/aceland-unity-packages).",
   "unity": "2022.3",
@@ -18,7 +18,7 @@
     "node"
   ],
   "dependencies": {
-    "com.aceland.library": "1.0.10",
+    "com.aceland.library": "1.0.11",
     "com.aceland.taskutils": "1.0.5"
   },
   "publishConfig": {


### PR DESCRIPTION
[MonoNode] duplicated initial root node if no childnode.
[MonoNode] rename StartOnNodeReady() to NodeAwake() for correct processing meaning.
[MonoNode] add OnNodeReadyAction(Action) to apply actions after NodeAwake invoked.